### PR TITLE
Support random address type and provide notification handler

### DIFF
--- a/bluepy/bluepy-helper.c
+++ b/bluepy/bluepy-helper.c
@@ -453,18 +453,15 @@ static void cmd_connect(int argcp, char **argvp)
 	if (conn_state != STATE_DISCONNECTED)
 		return;
 
-	if (argcp > 1) {
+	if (argcp > 2) {
 		g_free(opt_dst);
-		opt_dst = g_strdup(argvp[1]);
-
 		g_free(opt_dst_type);
-		if (argcp > 2)
-			opt_dst_type = g_strdup(argvp[2]);
-		else
-			opt_dst_type = g_strdup("public");
+
+		opt_dst = g_strdup(argvp[1]);
+		opt_dst_type = g_strdup(argvp[2]);
 	}
 
-	if (opt_dst == NULL) {
+	if (opt_dst == NULL || opt_dst_type == NULL) {
 		resp_error(err_BAD_PARAM);
 		return;
 	}

--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -133,7 +133,7 @@ class Peripheral:
     def __init__(self, deviceAddr=None, addressType='public'):
         if addressType not in ['public', 'random']:
             raise BTLEException(BTLEException.INTERNAL_ERROR,
-                                "addressType must public or random")
+                                "addressType must be public or random")
 
         self._helper = None
         self.services = {} # Indexed by UUID


### PR DESCRIPTION
I have a nRF8001 (actually a https://www.adafruit.com/product/1697) that requires some minor changes to bluepy to work. These changes should be backwards-compatible to not interfere with anyone's existing bluepy code.

Specifically I need support for random address type on the connection command, and a way to access the notifications coming back. Here is some example code I'm using with these new features:

```
from __future__ import print_function

import sys
import time

import btle


class nRF8001(btle.Peripheral):
    def notificationHandler(self, data):
        print('Got data:', data)


if __name__ == '__main__':
    if len(sys.argv) < 2:
        sys.exit('Usage:\n  %s <mac-address>' % sys.argv[0])

    devaddr = sys.argv[1]
    print('Connecting to:', devaddr)

    conn = nRF8001(devaddr, addressType='random')

    # Turn on notifications
    conn.writeCharacteristic(0x0e, '\x01\x00', False)

    # Write to device so it will send us update
    conn.writeCharacteristic(0x0b, 'A', False)

    # Wait for a bit to get a response
    time.sleep(1)

    conn.disconnect()
```

If you have this board, you should be able to run Adafruit's callbackEcho demo for the microcontroller side of things: https://github.com/adafruit/Adafruit_nRF8001/blob/master/examples/callbackEcho/callbackEcho.ino

I'm fairly familiar with C and Python, but pretty new to Bluetooth, so hopefully these changes make sense.