### PR TITLE
Buffer all the available data in LineReader

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -6,7 +6,7 @@ import os
 import time
 import subprocess
 import binascii
-import select
+from .line_reader import LineReader
 
 Debugging = False
 helperExe = os.path.join(os.path.abspath(os.path.dirname(__file__)), "bluepy-helper")
@@ -22,7 +22,6 @@ def DBG(*args):
     if Debugging:
         msg = " ".join([str(a) for a in args])
         print(msg)
-
 
 class BTLEException(Exception):
 
@@ -177,11 +176,10 @@ class DefaultDelegate:
     def handleNotification(self, cHandle, data):
         DBG("Notification:", cHandle, "sent data", binascii.b2a_hex(data))
 
-
 class Peripheral:
     def __init__(self, deviceAddr=None, addrType=ADDR_TYPE_PUBLIC):
         self._helper = None
-        self._poller = None
+        self._linereader = None
         self.services = {} # Indexed by UUID
 	self.addrType = addrType
         self.discoveredAllServices = False
@@ -195,17 +193,15 @@ class Peripheral:
     def _startHelper(self):
         if self._helper is None:
             DBG("Running ", helperExe)
-            self._helper = subprocess.Popen([helperExe],
+            self._helper = subprocess.Popen([helperExe], bufsize=0,
                                             stdin=subprocess.PIPE,
                                             stdout=subprocess.PIPE,
                                             universal_newlines=True)
-            self._poller = select.poll()
-            self._poller.register(self._helper.stdout, select.POLLIN)
+            self._linereader = LineReader(self._helper.stdout.fileno())
 
     def _stopHelper(self):
         if self._helper is not None:
             DBG("Stopping ", helperExe)
-            self._poller.unregister(self._helper.stdout)
             self._helper.stdin.write("quit\n")
             self._helper.stdin.flush()
             self._helper.wait()
@@ -244,17 +240,14 @@ class Peripheral:
         return resp
 
     def _getResp(self, wantType, timeout=None):
-        while True:
-            if self._helper.poll() is not None:
-                raise BTLEException(BTLEException.INTERNAL_ERROR, "Helper exited")
+        start_time = time.time()
+        while timeout is None or time.time() - start_time < timeout:
+            rv = self._linereader.readline(timeout)
 
-            if timeout:
-                fds = self._poller.poll(timeout*1000)
-                if len(fds) == 0:
-                    DBG("Select timeout")
-                    return None
-
-            rv = self._helper.stdout.readline()
+            if rv is None:
+                continue
+            # Convert from bytearray to string
+            rv = ''.join(map(chr, rv))
             DBG("Got:", repr(rv))
             if rv.startswith('#'):
                 continue

--- a/bluepy/line_reader.py
+++ b/bluepy/line_reader.py
@@ -1,0 +1,48 @@
+import os
+import time
+import select
+
+class LineReader(object):
+    """Read line by line from the file descriptor
+       Improved from http://stackoverflow.com/questions/5486717/python-select-doesnt-signal-all-input-from-pipe"""
+    def __init__(self, fd):
+        self._fd = fd
+        self._buf = b''
+        self._poller = select.poll()
+        self._poller.register(fd, select.POLLIN)
+
+    def fileno(self):
+        return self._fd
+
+    def readline(self, timeout=None):
+        """Get next line from the file descriptor.
+           If there is a line already buffered, it will be returned straight away.
+           Otherwise select.poll() will be called with timeout"""
+        ret = self._nextline()
+
+        # poll() when there is no line available
+        start_time = time.time()
+        while ret is None and (timeout is None or time.time() - start_time < timeout):
+            fds = self._poller.poll(-1 if timeout is None else timeout * 1000)
+            if len(fds) == 0:
+                DBG("Select timeout")
+                return None
+
+            data = os.read(self._fd, 4096)
+            if not data:
+                return None
+            self._buf += data
+            ret = self._nextline()
+        return ret
+
+    def _nextline(self):
+        """Try to get a line from the buffered bytes"""
+        if b'\n' not in self._buf:
+            return None
+        tmp = self._buf.split(b'\n')
+        line = tmp[0]
+        self._buf = self._buf[len(line) + 1:]
+        return line
+
+    def __del__(self):
+        self._poller.unregister(self._fd)


### PR DESCRIPTION
When there are two lines available for reading from the subprocess,
Python readline() actually reads all data from the pipe. This makes
the subsequent select.poll() not triggered as expected.

LineReader buffers all available data after select.poll() returns.
Its readline() method only polls again when there is no available
data in the buffer.