### PR TITLE
xively data upload and read 3 sensortags in a loop

### DIFF
--- a/bluepy/loop_3x_sensortags
+++ b/bluepy/loop_3x_sensortags
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+while :
+	do
+		timeout 10 python sensortag_xively.py -n 1 -H -f 175453399 -a YOURAPIID BC:6A:29:C3:4C:16 #place your own feed number and api id
+		timeout 10 python sensortag_xively.py -n 1 -H -f 199299397 -a YOURAPIID 34:B1:F7:D1:45:77 #from your  
+		timeout 10 python sensortag_xively.py -n 1 -H -f 211211846 -a YOURAPIID 34:B1:F7:D5:0C:14 #xively devices 
+done

--- a/bluepy/sensortag_xively.py
+++ b/bluepy/sensortag_xively.py
@@ -1,0 +1,306 @@
+from btle import UUID, Peripheral, DefaultDelegate
+import struct
+import math
+import xively
+import datetime
+
+def _TI_UUID(val):
+    return UUID("%08X-0451-4000-b000-000000000000" % (0xF0000000+val))
+
+class SensorBase:
+    # Derived classes should set: svcUUID, ctrlUUID, dataUUID
+    sensorOn  = struct.pack("B", 0x01)
+    sensorOff = struct.pack("B", 0x00)
+
+    def __init__(self, periph):
+        self.periph = periph
+        self.service = None
+        self.ctrl = None
+        self.data = None
+
+    def enable(self):
+        if self.service is None:
+            self.service = self.periph.getServiceByUUID(self.svcUUID)
+        if self.ctrl is None:
+            self.ctrl = self.service.getCharacteristics(self.ctrlUUID) [0]
+        if self.data is None:
+            self.data = self.service.getCharacteristics(self.dataUUID) [0]
+        if self.sensorOn is not None:
+            self.ctrl.write(self.sensorOn,withResponse=True)
+
+    def read(self):
+        return self.data.read()
+
+    def disable(self):
+        if self.ctrl is not None:
+            self.ctrl.write(self.sensorOff)
+
+    # Derived class should implement _formatData()
+
+def calcPoly(coeffs, x):
+    return coeffs[0] + (coeffs[1]*x) + (coeffs[2]*x*x)
+
+class IRTemperatureSensor(SensorBase):
+    svcUUID  = _TI_UUID(0xAA00)
+    dataUUID = _TI_UUID(0xAA01)
+    ctrlUUID = _TI_UUID(0xAA02)
+
+    zeroC = 273.15 # Kelvin
+    tRef  = 298.15
+    Apoly = [1.0,      1.75e-3, -1.678e-5]
+    Bpoly = [-2.94e-5, -5.7e-7,  4.63e-9]
+    Cpoly = [0.0,      1.0,      13.4]
+
+    def __init__(self, periph):
+        SensorBase.__init__(self, periph)
+        self.S0 = 6.4e-14
+
+    def read(self):
+        '''Returns (ambient_temp, target_temp) in degC'''
+
+        # See http://processors.wiki.ti.com/index.php/SensorTag_User_Guide#IR_Temperature_Sensor
+        (rawVobj, rawTamb) = struct.unpack('<hh', self.data.read())
+        tAmb = rawTamb / 128.0
+        Vobj = 1.5625e-7 * rawVobj
+
+        tDie = tAmb + self.zeroC
+        S   = self.S0 * calcPoly(self.Apoly, tDie-self.tRef)
+        Vos = calcPoly(self.Bpoly, tDie-self.tRef)
+        fObj = calcPoly(self.Cpoly, Vobj-Vos)
+
+        tObj = math.pow( math.pow(tDie,4.0) + (fObj/S), 0.25 )
+        return (tAmb, tObj - self.zeroC)
+
+
+class AccelerometerSensor(SensorBase):
+    svcUUID  = _TI_UUID(0xAA10)
+    dataUUID = _TI_UUID(0xAA11)
+    ctrlUUID = _TI_UUID(0xAA12)
+
+    def __init__(self, periph):
+        SensorBase.__init__(self, periph)
+
+    def read(self):
+        '''Returns (x_accel, y_accel, z_accel) in units of g'''
+        x_y_z = struct.unpack('bbb', self.data.read())
+        return tuple([ (val/64.0) for val in x_y_z ])
+
+class HumiditySensor(SensorBase):
+    svcUUID  = _TI_UUID(0xAA20)
+    dataUUID = _TI_UUID(0xAA21)
+    ctrlUUID = _TI_UUID(0xAA22)
+
+    def __init__(self, periph):
+        SensorBase.__init__(self, periph)
+
+    def read(self):
+        '''Returns (ambient_temp, rel_humidity)'''
+        (rawT, rawH) = struct.unpack('<HH', self.data.read())
+        temp = -46.85 + 175.72 * (rawT / 65536.0)
+        RH = -6.0 + 125.0 * ((rawH & 0xFFFC)/65536.0)
+        return (temp, RH)
+
+
+class MagnetometerSensor(SensorBase):
+    svcUUID  = _TI_UUID(0xAA30)
+    dataUUID = _TI_UUID(0xAA31)
+    ctrlUUID = _TI_UUID(0xAA32)
+
+    def __init__(self, periph):
+        SensorBase.__init__(self, periph)
+
+    def read(self):
+        '''Returns (x, y, z) in uT units'''
+        x_y_z = struct.unpack('<hhh', self.data.read())
+        return tuple([ 1000.0 * (v/32768.0) for v in x_y_z ])
+        # Revisit - some absolute calibration is needed
+
+class BarometerSensor(SensorBase):
+    svcUUID  = _TI_UUID(0xAA40)
+    dataUUID = _TI_UUID(0xAA41)
+    ctrlUUID = _TI_UUID(0xAA42)
+    calUUID  = _TI_UUID(0xAA43)
+    sensorOn = None
+
+    def __init__(self, periph):
+       SensorBase.__init__(self, periph)
+
+    def enable(self):
+        SensorBase.enable(self)
+        self.calChr = self.service.getCharacteristics(self.calUUID) [0]
+
+        # Read calibration data
+        self.ctrl.write( struct.pack("B", 0x02), True )
+        (c1,c2,c3,c4,c5,c6,c7,c8) = struct.unpack("<HHHHhhhh", self.calChr.read())
+        self.c1_s = c1/float(1 << 24)
+        self.c2_s = c2/float(1 << 10)
+        self.sensPoly = [ c3/1.0, c4/float(1 << 17), c5/float(1<<34) ]
+        self.offsPoly = [ c6*float(1<<14), c7/8.0, c8/float(1<<19) ]
+        self.ctrl.write( struct.pack("B", 0x01), True )
+
+
+    def read(self):
+        '''Returns (ambient_temp, pressure_millibars)'''
+        (rawT, rawP) = struct.unpack('<hH', self.data.read())
+        temp = (self.c1_s * rawT) + self.c2_s
+        sens = calcPoly( self.sensPoly, float(rawT) )
+        offs = calcPoly( self.offsPoly, float(rawT) )
+        pres = (sens * rawP + offs) / (100.0 * float(1<<14))
+        return (temp,pres)
+
+
+class GyroscopeSensor(SensorBase):
+    svcUUID  = _TI_UUID(0xAA50)
+    dataUUID = _TI_UUID(0xAA51)
+    ctrlUUID = _TI_UUID(0xAA52)
+    sensorOn = struct.pack("B",0x07)
+
+    def __init__(self, periph):
+       SensorBase.__init__(self, periph)
+
+    def read(self):
+        '''Returns (x,y,z) rate in deg/sec'''
+        x_y_z = struct.unpack('<hhh', self.data.read())
+        return tuple([ 250.0 * (v/32768.0) for v in x_y_z ])
+
+class KeypressSensor(SensorBase):
+    svcUUID = UUID(0xFFE0)
+    dataUUID = UUID(0xFFE1)
+
+    def __init__(self, periph):
+        SensorBase.__init__(self, periph)
+ 
+    def enable(self):
+        self.periph.writeCharacteristic(0x60, struct.pack('<bb', 0x01, 0x00))
+
+    def disable(self):
+        self.periph.writeCharacteristic(0x60, struct.pack('<bb', 0x00, 0x00))
+
+class SensorTag(Peripheral):
+    def __init__(self,addr):
+        Peripheral.__init__(self,addr)
+        # self.discoverServices()
+        self.IRtemperature = IRTemperatureSensor(self)
+        self.accelerometer = AccelerometerSensor(self)
+        self.humidity = HumiditySensor(self)
+        self.magnetometer = MagnetometerSensor(self)
+        self.barometer = BarometerSensor(self)
+        self.gyroscope = GyroscopeSensor(self)
+        self.keypress = KeypressSensor(self)
+
+
+class KeypressDelegate(DefaultDelegate):
+    BUTTON_L = 0x02
+    BUTTON_R = 0x01
+    ALL_BUTTONS = (BUTTON_L | BUTTON_R)
+
+    _button_desc = { 
+        BUTTON_L : "Left button",
+        BUTTON_R : "Right button",
+        ALL_BUTTONS : "Both buttons"
+    } 
+
+    def __init__(self):
+        DefaultDelegate.__init__(self)
+        self.lastVal = 0
+
+    def handleNotification(self, hnd, data):
+        # NB: only one source of notifications at present
+        # so we can ignore 'hnd'.
+        val = struct.unpack("B", data)[0]
+        down = (val & ~self.lastVal) & self.ALL_BUTTONS
+        if down != 0:
+            self.onButtonDown(down)
+        up = (~val & self.lastVal) & self.ALL_BUTTONS
+        if up != 0:
+            self.onButtonUp(up)
+        self.lastVal = val
+
+    def onButtonUp(self, but):
+        print ( "** " + self._button_desc[but] + " UP")
+
+    def onButtonDown(self, but):
+        print ( "** " + self._button_desc[but] + " DOWN")
+
+if __name__ == "__main__":
+    import time
+    import sys
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('host', action='store',help='MAC of BT device')
+    parser.add_argument('-f','--feedid', action='store',type=int, help='Xively Feed ID', default=0)
+    parser.add_argument('-a','--apicode', action='store', help='Xively API Code', default='')
+    parser.add_argument('-n', action='store', dest='count', default=0,
+            type=int, help="Number of times to loop data")
+    parser.add_argument('-t',action='store',type=float, default=5.0, help='time between polling')
+    parser.add_argument('-T','--temperature', action="store_true",default=False)
+    parser.add_argument('-A','--accelerometer', action='store_true',
+            default=False)
+    parser.add_argument('-H','--humidity', action='store_true', default=False)
+    parser.add_argument('-M','--magnetometer', action='store_true',
+            default=False)
+    parser.add_argument('-B','--barometer', action='store_true', default=False)
+    parser.add_argument('-G','--gyroscope', action='store_true', default=False)
+    parser.add_argument('-K','--keypress', action='store_true', default=False)
+    parser.add_argument('--all', action='store_true', default=False)
+
+    arg = parser.parse_args(sys.argv[1:])
+
+    print('Connecting to ' + arg.host)
+    tag = SensorTag(arg.host)
+
+    if arg.feedid != 0 and arg.apicode != '':
+        api = xively.XivelyAPIClient(arg.apicode)
+        feed = api.feeds.get(arg.feedid)
+
+    # Enabling selected sensors
+    if arg.temperature or arg.all:
+        tag.IRtemperature.enable()
+    if arg.humidity or arg.all:
+        tag.humidity.enable()
+    if arg.barometer or arg.all:
+        tag.barometer.enable()
+    if arg.accelerometer or arg.all:
+        tag.accelerometer.enable()
+    if arg.magnetometer or arg.all:
+        tag.magnetometer.enable()
+    if arg.gyroscope or arg.all:
+        tag.gyroscope.enable()
+    if arg.keypress or arg.all:
+        tag.keypress.enable()
+        tag.setDelegate(KeypressDelegate())
+
+    # Some sensors (e.g., temperature, accelerometer) need some time for initialization.
+    # Not waiting here after enabling a sensor, the first read value might be empty or incorrect.
+    time.sleep(1.0)
+
+    counter=1
+    while True:
+       if arg.temperature or arg.all:
+           print('Temp: ', tag.IRtemperature.read())
+       if arg.humidity or arg.all:
+           data = tag.humidity.read()
+           now = datetime.datetime.now()
+           print data	   
+           if arg.feedid != 0 and arg.apicode != '':
+               feed.datastreams = [ 
+                   xively.Datastream(id='temperature', current_value = round(data[0],1), at=now), 
+                   xively.Datastream(id='humidity', current_value = round(data[1],0), at=now) 
+               ]
+               feed.update()
+       if arg.barometer or arg.all:
+           print("Barometer: ", tag.barometer.read())
+       if arg.accelerometer or arg.all:
+           print("Accelerometer: ", tag.accelerometer.read())
+       if arg.magnetometer or arg.all:
+           print("Magnetometer: ", tag.magnetometer.read())
+       if arg.gyroscope or arg.all:
+           print("Gyroscope: ", tag.gyroscope.read())
+       if counter >= arg.count and arg.count != 0:
+           break
+       counter += 1
+       tag.waitForNotifications(arg.t)
+
+    tag.disconnect()
+    del tag


### PR DESCRIPTION
Add sensortag xively support (data upstream only for the humidity sensors data) and also add a bash script to poll 3 sensortags. Otherwise only two sensortag connections at the same time seems to work. Best option is to use the sensortag firmware from the app myweathercenter, so the sensortag is advertising in 300 ms intervals constantly.
I made a new sensortag_xively.py file because xively needs a extra python lib and not everybody needs this feature. (https://github.com/xively/xively-python)