### PR TITLE
Add cmdline argument to bluepy-helper for scanning

### DIFF
--- a/bluepy/bluepy-helper.c
+++ b/bluepy/bluepy-helper.c
@@ -1541,19 +1541,19 @@ int main(int argc, char *argv[])
 			read_version_complete, NULL, NULL) == 0) {
 		DBG("mgmt_send(MGMT_OP_READ_VERSION) failed");
 	}
-
-	if (mgmt_register(mgmt_master, MGMT_EV_DEVICE_CONNECTED, 0, mgmt_device_connected, NULL, NULL)==0) {
+        if (argc >= 2) {
+	    if (mgmt_register(mgmt_master, MGMT_EV_DEVICE_CONNECTED, 0, mgmt_device_connected, NULL, NULL)==0) {
 		DBG("mgmt_register(MGMT_EV_DEVICE_CONNECTED) failed");
-	}
+	    }
 
-	if (mgmt_register(mgmt_master, MGMT_EV_DISCOVERING, 0, mgmt_scanning, NULL, NULL)) {
+	    if (mgmt_register(mgmt_master, MGMT_EV_DISCOVERING, 0, mgmt_scanning, NULL, NULL)) {
 		DBG("mgmt_register(MGMT_EV_DISCOVERING) failed");
-	}
+	    }
 
-	if (mgmt_register(mgmt_master, MGMT_EV_DEVICE_FOUND, 0, mgmt_device_found, NULL, NULL)) {
+	    if (mgmt_register(mgmt_master, MGMT_EV_DEVICE_FOUND, 0, mgmt_device_found, NULL, NULL)) {
 		DBG("mgmt_register(MGMT_EV_DEVICE_FOUND) failed");
-	}
-
+	    }
+        }
 	event_loop = g_main_loop_new(NULL, FALSE);
 
 	pchan = g_io_channel_unix_new(fileno(stdin));

--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -189,11 +189,13 @@ class Bluepy:
         self._poller = None
         self._stderr = None
 
-    def _startHelper(self):
+    def _startHelper(self,scan=False):
         if self._helper is None:
             DBG("Running ", helperExe)
             self._stderr = open(os.devnull, "w")
-            self._helper = subprocess.Popen([helperExe],
+            args=[helperExe]
+            if scan: args.append("scan")
+            self._helper = subprocess.Popen(args,
                                             stdin=subprocess.PIPE,
                                             stdout=subprocess.PIPE,
                                             stderr=self._stderr,
@@ -460,7 +462,7 @@ class Scan(Bluepy):
         self.callback = None
 
     def start(self):
-        self._startHelper()
+        self._startHelper(scan=True)
         self._mgmtCmd("le on")
         self._writeCmd("scan\n")
         rsp = self._waitResp("mgmt")

--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -194,7 +194,7 @@ class Bluepy:
             DBG("Running ", helperExe)
             self._stderr = open(os.devnull, "w")
             args=[helperExe]
-            if index: args.append(str(index))
+            if index is not None: args.append(str(index))
             self._helper = subprocess.Popen(args,
                                             stdin=subprocess.PIPE,
                                             stdout=subprocess.PIPE,
@@ -465,7 +465,7 @@ class Scan(Bluepy):
         self.scanned = {}
         self.callback = None
         self.index=index
-
+    
     def start(self):
         self._startHelper(index=self.index)
         self._mgmtCmd("le on")


### PR DESCRIPTION
This is the small fix associated with the issue i just opened.
The mgm functions registered to enable scanning leak responses across all helper processes which causes problems for peripherals that are connected.

With this fix I can run a single scanning thread side-by-side with multiple device threads, each with their own running bluepy-helper process. 

You cannot run multiple scanning helpers concurrently however.
