### PR TITLE
Descriptors

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -119,7 +119,7 @@ class Service:
             # Note that this does not filter out characteristic value descriptors
             self.descs = [desc for desc in all_descs if desc.uuid != 0x2803]
         if forUUID is not None:
-            u = UUID(for_UUID)
+            u = UUID(forUUID)
             return [desc for desc in self.descs if desc.uuid == u]
         return self.descs
 
@@ -174,7 +174,7 @@ class Characteristic:
                     break
                 self.descs.append(desc)
         if forUUID is not None:
-            u = UUID(for_UUID)
+            u = UUID(forUUID)
             return [desc for desc in self.descs if desc.uuid == u]
         return self.descs
 


### PR DESCRIPTION
This isn't really ready to merge yet; I'd like to get feedback on how to handle descriptors first.

I've added the ability to retrieve descriptors by grabbing all of the handles in a service's or characteristic's range and filtering out the handles that correspond to things we don't usually think of as descriptors (like the descriptor for declaring a characteristic's properties or the descriptor for declaring a primary service).

With the new `Characteristic.getDescriptor()` method, setting up notifications now looks like:

```
char = peripheral.getCharacteristics(uuid=your_uuid_here)[0]
ccc_desc = char.getDescriptors(forUUID=0x2902)[0]
ccc_desc.write(b"\x01")
```

Things I'd like feedback on:
- Is  there a particular style convention I should adhere to? I see there's a policy on indentation whitespace for Python code, but nothing more specific.
- What descriptors should be included for a service vs a characteristic?
  For a service, right now it just returns everything except for characteristic declarations (0x2803) and the service declaration (0x2800 and 0x2801). The only actual service-specific descriptor that I know of is the include descriptor (0x2802).
  For characteristics, the value descriptor is somewhat redundant since the Characteristic object already allows operations on the value descriptor, but there's a sort of consistency to retaining it.
- Which object should be responsible for retrieving descriptors? Most of the time, I expect someone would want to retrieve a characteristic's descriptors (namely, the Client Characteristic Configuration descriptor for notifications), but doing it from the characteristic is expensive because it doesn't know what handle range to limit itself to.
- I didn't include the change here, but at least on my setup the final service always has an end handle of 0xFFFF, which causes `Peripheral.getDescriptors()` to wait for more handles than it can ever hope to find. I've been working around it by only doing a single read from `bluetooth_helper`. Is there a better solution?
