### PR TITLE
Exposing btle and tagsensor to the top level module

### DIFF
--- a/bluepy/__init__.py
+++ b/bluepy/__init__.py
@@ -1,1 +1,4 @@
+from __future__ import  absolute_import
+from . import btle
+from . import sensortag
 __all__ = ["btle", "sensortag"]


### PR DESCRIPTION
The idea of this code is to expose the btle and tagsensor once you import ``bluepy``

```python
import bluepy
bluepy.btle # works with this trick
```