### PR TITLE
Fix error reporting when compile fails.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def pre_install():
         print("Failed to compile bluepy-helper. Exiting install.")
         print("Command was " + repr(cmd) + " in " + os.getcwd())
         print("Return code was %d" % e.returncode)
-        print("Output was:\n" + e.output)
+        print("Output was:\n%s" % e.output)
         sys.exit(1)
 
 def post_install():


### PR DESCRIPTION
My Docker didn't had all dependencies set up yet so I got the following error. Python 3 does not allow concatenating bytes and strings.

```
    Traceback (most recent call last):
      File "/tmp/pip-build-y7otqrxw/bluepy/setup.py", line 16, in pre_install
        msgs = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
      File "/usr/local/lib/python3.4/subprocess.py", line 620, in check_output
        raise CalledProcessError(retcode, process.args, output=output)
    subprocess.CalledProcessError: Command '['make', '-C', './bluepy']' returned non-zero exit status 2
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-y7otqrxw/bluepy/setup.py", line 70, in <module>
        'blescan=bluepy.blescan:main',
      File "/usr/local/lib/python3.4/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/local/lib/python3.4/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/usr/local/lib/python3.4/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/tmp/pip-build-y7otqrxw/bluepy/setup.py", line 33, in custom_run
        pre_install()
      File "/tmp/pip-build-y7otqrxw/bluepy/setup.py", line 21, in pre_install
        print("Output was:\n" + e.output)
    TypeError: Can't convert 'bytes' object to str implicitly
```