### PR TITLE
Add a missing return in the Characteristic.write functio

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -145,7 +145,7 @@ class Characteristic:
         return self.peripheral.readCharacteristic(self.valHandle)
 
     def write(self, val, withResponse=False):
-        self.peripheral.writeCharacteristic(self.valHandle, val, withResponse)
+        return self.peripheral.writeCharacteristic(self.valHandle, val, withResponse)
 
     # TODO: descriptors
 


### PR DESCRIPTION
To have the same behavior as Peripheral.writeCharacteristic(...)