### PR TITLE
Fix python packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include bluepy/bluepy-helper

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include bluepy/bluepy-helper

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from setuptools.command.install import install
 from setuptools.command.develop import develop
+from setuptools.command.build_ext import build_ext
 from setuptools import setup
 import subprocess
 import shlex
@@ -47,6 +48,10 @@ class BluepyInstall(install):
 class BluepyDevelop(develop):
     pass
 
+@setup_command
+class BluepyBuildExt(build_ext):
+    pass
+
 setup (
     name='bluepy',
     version='1.0.5',
@@ -65,7 +70,11 @@ setup (
     package_data={
         'bluepy': ['bluepy-helper', '*.json', 'bluez-src.tgz', 'bluepy-helper.c', 'Makefile']
     },
-    cmdclass={'install': BluepyInstall, 'develop': BluepyDevelop},
+    cmdclass={
+        'install': BluepyInstall,
+        'develop': BluepyDevelop,
+        'build_ext': BluepyBuildExt,
+    },
     entry_points={
         'console_scripts': [
             'sensortag=bluepy.sensortag:main',


### PR DESCRIPTION
Include compiled "bluepy-helper".

I prefer install this library using `pip install bluepy`. But this wasn't work.
This PR will be fix that problem.