### PR TITLE
Fixing crash when getServiceByUUID is called before services are cached

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -435,13 +435,16 @@ class Peripheral(BluepyHelper):
 
     def getServiceByUUID(self, uuidVal):
         uuid = UUID(uuidVal)
-        if uuid in self._serviceMap:
+        if self._serviceMap is not None and uuid in self._serviceMap:
             return self._serviceMap[uuid]
         self._writeCmd("svcs %s\n" % uuid)
         rsp = self._getResp('find')
         if 'hstart' not in rsp:
             raise BTLEException(BTLEException.GATT_ERROR, "Service %s not found" % (uuid.getCommonName()))
         svc = Service(self, uuid, rsp['hstart'][0], rsp['hend'][0])
+        if self._serviceMap is None:
+            self._serviceMap = {}
+
         self._serviceMap[uuid] = svc
         return svc
 

--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -442,9 +442,9 @@ class Peripheral(BluepyHelper):
         if 'hstart' not in rsp:
             raise BTLEException(BTLEException.GATT_ERROR, "Service %s not found" % (uuid.getCommonName()))
         svc = Service(self, uuid, rsp['hstart'][0], rsp['hend'][0])
+        
         if self._serviceMap is None:
             self._serviceMap = {}
-
         self._serviceMap[uuid] = svc
         return svc
 


### PR DESCRIPTION
This diff gracefully handles `self._serviceMap` being `None` initially. Otherwise would crash on line 438