### PR TITLE
updating Peripheral.connect to allow ScanEntry

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -348,9 +348,9 @@ class Peripheral(BluepyHelper):
         (self.deviceAddr, self.addrType, self.iface) = (None, None, None)
 
         if isinstance(deviceAddr, ScanEntry):
-            self.connect(deviceAddr.addr, deviceAddr.addrType, deviceAddr.iface)
+            self._connect(deviceAddr.addr, deviceAddr.addrType, deviceAddr.iface)
         elif deviceAddr is not None:
-            self.connect(deviceAddr, addrType, iface)
+            self._connect(deviceAddr, addrType, iface)
 
     def setDelegate(self, delegate_): # same as withDelegate(), deprecated
         return self.withDelegate(delegate_)
@@ -380,7 +380,7 @@ class Peripheral(BluepyHelper):
                     continue
             return resp
 
-    def connect(self, addr, addrType=ADDR_TYPE_PUBLIC, iface=None):
+    def _connect(self, addr, addrType=ADDR_TYPE_PUBLIC, iface=None):
         if len(addr.split(":")) != 6:
             raise ValueError("Expected MAC address, got %s" % repr(addr))
         if addrType not in (ADDR_TYPE_PUBLIC, ADDR_TYPE_RANDOM):
@@ -400,6 +400,12 @@ class Peripheral(BluepyHelper):
             self._stopHelper()
             raise BTLEException(BTLEException.DISCONNECTED,
                                 "Failed to connect to peripheral %s, addr type: %s" % (addr, addrType))
+
+    def connect(self, addr, addrType=ADDR_TYPE_PUBLIC, iface=None):
+        if isinstance(addr, ScanEntry):
+            self._connect(addr.addr, addr.addrType, addr.iface)
+        elif addr is not None:
+            self._connect(addr, addrType, iface)
 
     def disconnect(self):
         if self._helper is None:


### PR DESCRIPTION
small update to allow connect to be called with a ScanEntry object just like the constructor is able to.