### PR TITLE
Add passive scan capabilities

### DIFF
--- a/bluepy/scanner.py
+++ b/bluepy/scanner.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+from __future__ import print_function
+
+from time import gmtime, strftime, sleep
+from bluepy.btle import Scanner, DefaultDelegate, BTLEException
+import sys
+
+
+class ScanDelegate(DefaultDelegate):
+
+    def handleDiscovery(self, dev, isNewDev, isNewData):
+        print(strftime("%Y-%m-%d %H:%M:%S", gmtime()), dev.addr, dev.getScanData())
+        sys.stdout.flush()
+
+scanner = Scanner().withDelegate(ScanDelegate())
+
+# listen for ADV_IND packages for 10s, then exit
+scanner.scan(10.0, passive=True)


### PR DESCRIPTION
- Add commands `pasv` and `pasvend` to bluepy-helper using HCI to listen for `ADV_IND` packages only
- Add option `passive` to Scanner class, switching between `scan`/`scanend` and `pasv`/`pasvend`
- Add example script `scanner.py`