### PR TITLE
Fix Peripheral bug: connections fail on hci1

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -385,7 +385,7 @@ class Peripheral(BluepyHelper):
             raise ValueError("Expected MAC address, got %s" % repr(addr))
         if addrType not in (ADDR_TYPE_PUBLIC, ADDR_TYPE_RANDOM):
             raise ValueError("Expected address type public or random, got {}".format(addrType))
-        self._startHelper()
+        self._startHelper(iface)
         self.addr = addr
         self.addrType = addrType
         self.iface = iface


### PR DESCRIPTION
The _connect command is passed a parameter 'iface' for the Bluetooth
interface index, but it is never passed to _startHelper here (as it is
in Scanner.start).  As a result, if a different interface than hci0 is
in use, Peripheral will fail to ever connect because the helper is
never passed the correct interface as a commandline option.  This
issue appeared on a laptop where the built-in Bluetooth interface is
on hci0 but is too old to support Bluetooth Low Energy, while a
separate USB device, hci1, is the one I intended to use.