### PR TITLE
Makefile : Don't override env. variables

### DIFF
--- a/bluepy/Makefile
+++ b/bluepy/Makefile
@@ -9,10 +9,10 @@ BLUEZ_SRCS += src/shared/io-glib.c src/shared/timeout-glib.c
 IMPORT_SRCS = $(addprefix $(BLUEZ_PATH)/, $(BLUEZ_SRCS))
 LOCAL_SRCS  = bluepy-helper.c
 
-CC = gcc
-CFLAGS = -Os -g -Wall # -Werror
+CC ?= gcc
+CFLAGS += -Os -g -Wall # -Werror
 
-CPPFLAGS = -DHAVE_CONFIG_H
+CPPFLAGS += -DHAVE_CONFIG_H
 ifneq ($(DEBUGGING),)
 CFLAGS += -DBLUEPY_DEBUG=1
 endif


### PR DESCRIPTION
Changed the makefile so it doesn't override parameters coming from the environment, to let toolchains that can hook into pip (such as OpenWRT/LEDE) provide their own compilation setup.

The resulting bluepy-helper has the same MD5 sum on my machine with and without those changes, but attempting to compile this using openWRT's toolchain creates a binary of the correct architecture for the compilation target instead of the compilation host.