### PR TITLE
bluepy-helper should ignore SIGINT 

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -10,6 +10,12 @@ import subprocess
 import binascii
 import select
 import struct
+import signal
+
+def preexec_function():
+    # Ignore the SIGINT signal by setting the handler to the standard
+    # signal handler SIG_IGN.
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 Debugging = False
 script_path = os.path.join(os.path.abspath(os.path.dirname(__file__)))
@@ -243,7 +249,8 @@ class BluepyHelper:
                                             stdin=subprocess.PIPE,
                                             stdout=subprocess.PIPE,
                                             stderr=self._stderr,
-                                            universal_newlines=True)
+                                            universal_newlines=True,
+                                            preexec_fn = preexec_function)
             self._poller = select.poll()
             self._poller.register(self._helper.stdout, select.POLLIN)
 


### PR DESCRIPTION
Make the subprocess for bluepy-helper ignore SIGINT so controlling Python applications can shut down cleanly.

Now applications can do something like:

```
try:
    # Enable notifications
    delegate.writeCharacteristic(cccd, struct.pack('<bb', 0x01, 0x00))
    while True:
        if delegate.waitForNotifications(1.0):
            continue
except KeyboardInterrupt:
    # Disable notifications
    delegate.writeCharacteristic(cccd, struct.pack('<bb', 0x00, 0x00))
    del delegate
```

This addresses https://github.com/IanHarvey/bluepy/issues/191