### PR TITLE
Handling for broken device names. Closes #259

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -621,7 +621,13 @@ class ScanEntry:
         if val is None:
             return None
         if (sdid==8) or (sdid==9):
-            return val.decode('utf-8')
+            try:
+                return val.decode('utf-8')
+            except UnicodeDecodeError:
+                try:
+                    return val.decode('ISO-8859-1')
+                except UnicodeDecodeError:
+                    return "broken encoding"
         else:
             return binascii.b2a_hex(val).decode('utf-8')
 


### PR DESCRIPTION
I also experienced crashing bluepy thanks to broken device names (as in #259).
This change fixes it.
The fallback to ISO-8859-1 worked in my case. For other nasty situations I also added a default handler for good measure.