### PR TITLE
fixed conversion of gas data (hex numbers, not decimal numbers)

### DIFF
--- a/bluepy/thingy52.py
+++ b/bluepy/thingy52.py
@@ -670,8 +670,8 @@ class MyDelegate(DefaultDelegate):
     def _extract_gas_data(self, data):
         """ Extract gas data from data string. """
         teptep = binascii.b2a_hex(data)
-        eco2 = int(teptep[:2]) + (int(teptep[2:4]) << 8)
-        tvoc = int(teptep[4:6]) + (int(teptep[6:8]) << 8)
+        eco2 = int(teptep[:2], 16) + (int(teptep[2:4], 16) << 8)
+        tvoc = int(teptep[4:6], 16) + (int(teptep[6:8], 16) << 8)
         return eco2, tvoc
 
     def _extract_tap_data(self, data):


### PR DESCRIPTION
The gas numbers sent by my thingy are encoded in hex, not in decimal, so a conversion is needed to get the correct values for eCO2 and TVOC.

This is also done in the nodejs library of Nordic (https://github.com/NordicPlayground/Nordic-Thingy52-Nodejs/blob/master/lib/thingy.js)
```js
Thingy.prototype.onGasNotif = function(data) {
    var gas = {
        eco2 : data.readUInt16LE(0),
        tvoc : data.readUInt16LE(2)
    }

    this.emit('gasNotif', gas);
};
```
