### PR TITLE
Remove extra indentation in _getResp() function causing it to not wait for the "wanted" response type

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -414,8 +414,8 @@ class Peripheral(BluepyHelper):
                 data = resp['d'][0]
                 if self.delegate is not None:
                     self.delegate.handleNotification(hnd, data)
-                if respType not in wantType:
-                    continue
+            if respType not in wantType:
+                continue
             return resp
 
     def _connect(self, addr, addrType=ADDR_TYPE_PUBLIC, iface=None):


### PR DESCRIPTION
The extra indentation in _getResp causes the check for not receiving the desired response type to be skipped.
I'm assuming that check allows the function to loop until the desired response is received.
But due to the extra indentation it's skipped.