### PR TITLE
Change the state changed to at the end of a scan from disconnected.

### DIFF
--- a/bluepy/bluepy-helper.c
+++ b/bluepy/bluepy-helper.c
@@ -1999,7 +1999,7 @@ static void mgmt_scanning(uint16_t index, uint16_t length,
 
     DBG("Scanning (0x%x): %s", ev->type, ev->discovering? "started" : "ended");
 
-    set_state(ev->discovering? STATE_SCANNING : STATE_DISCONNECTED);
+    set_state(ev->discovering? STATE_SCANNING : STATE_CONNECTED);
 }
 
 static void mgmt_device_found(uint16_t index, uint16_t length,


### PR DESCRIPTION
This resolves an issue when scanning whilst currently connected
to devices.

This might not be a good fix to the issue I'm having, and possibly further testing will shed some light onto a better fix, for this will possibly result in comments from maintainers who have a better idea what is going on.

The problem I'm having is probably very dependant on the use case I'm working on. Basically I'm connecting to a number of Bluetooth LE Sensors. Now the sensors can be powered on asynchronously so to facilitate that I perform a scan for 10 seconds every minute, connecting to any sensors which have powered up. 

The problem is that scanning for new sensors disconnects any previously connected sensors. To get around that issue I've simply changed the state transitioned to at the end of a scan. This is a quick and dirty fix and the only reason I'm creating this pull request is in search of comments on the issue. 