### PR TITLE
Bugfix: use self in disable() methods in thingy52

### DIFF
--- a/bluepy/thingy52.py
+++ b/bluepy/thingy52.py
@@ -233,11 +233,11 @@ class EnvironmentService():
             self.config_char.write(binascii.a2b_hex(new_config), True)
 
     def disable(self):
-        set_temperature_notification(False)
-        set_pressure_notification(False)
-        set_humidity_notification(False)
-        set_gas_notification(False)
-        set_color_notification(False)
+        self.set_temperature_notification(False)
+        self.set_pressure_notification(False)
+        self.set_humidity_notification(False)
+        self.set_gas_notification(False)
+        self.set_color_notification(False)
 
 
 class UserInterfaceService():
@@ -305,7 +305,7 @@ class UserInterfaceService():
                 self.btn_char_cccd.write(b"\x00\x00", True)
 
     def disable(self):
-        set_btn_notification(False)
+        self.set_btn_notification(False)
 
 
 class MotionService():
@@ -487,15 +487,15 @@ class MotionService():
             self.config_char.write(binascii.a2b_hex(new_config), True)
 
     def disable(self):
-        set_tap_notification(False)
-        set_orient_notification(False)
-        set_quaternion_notification(False)
-        set_stepcnt_notification(False)
-        set_rawdat_notification(False)
-        set_euler_notification(False)
-        set_rotation_notification(False)
-        set_heading_notification(False)
-        set_gravity_notification(False)
+        self.set_tap_notification(False)
+        self.set_orient_notification(False)
+        self.set_quaternion_notification(False)
+        self.set_stepcnt_notification(False)
+        self.set_rawdat_notification(False)
+        self.set_euler_notification(False)
+        self.set_rotation_notification(False)
+        self.set_heading_notification(False)
+        self.set_gravity_notification(False)
 
 
 class SoundService():
@@ -568,8 +568,8 @@ class SoundService():
             self.config_char.write(binascii.a2b_hex(new_config), True)
 
     def disable(self):
-        set_speaker_status_notification(False)
-        set_microphone_notification(False)
+        self.set_speaker_status_notification(False)
+        self.set_microphone_notification(False)
 
 
 class MyDelegate(DefaultDelegate):

--- a/bluepy/thingy52.py
+++ b/bluepy/thingy52.py
@@ -490,6 +490,7 @@ class MotionService():
         self.set_orient_notification(False)
         self.set_quaternion_notification(False)
         self.set_stepcnt_notification(False)
+        self.set_rawdata_notification(False)
         self.set_euler_notification(False)
         self.set_rotation_notification(False)
         self.set_heading_notification(False)

--- a/bluepy/thingy52.py
+++ b/bluepy/thingy52.py
@@ -490,7 +490,6 @@ class MotionService():
         self.set_orient_notification(False)
         self.set_quaternion_notification(False)
         self.set_stepcnt_notification(False)
-        self.set_rawdat_notification(False)
         self.set_euler_notification(False)
         self.set_rotation_notification(False)
         self.set_heading_notification(False)

--- a/bluepy/thingy52.py
+++ b/bluepy/thingy52.py
@@ -1,7 +1,6 @@
 from bluepy.btle import UUID, Peripheral, ADDR_TYPE_RANDOM, DefaultDelegate
 import argparse
 import time
-import struct
 import binascii
 
 def write_uint16(data, value, index):


### PR DESCRIPTION
Right now, none of the `disable()` methods in `thingy52` work because they contain calls to class methods which are not called using `self.`.

In addition, I also removed an unused import and a call to a non-existing method.