### PR TITLE
Handle MTU request from peripheral

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -563,7 +563,7 @@ class Peripheral(BluepyHelper):
         self._mgmtCmd("pair")
 
     def getMTU(self):
-        return self._mtu;
+        return self._mtu
 
     def setMTU(self, mtu):
         self._writeCmd("mtu %x\n" % mtu)


### PR DESCRIPTION
There are peripherals that initiate an MTU exchange request, but currently bluepy rejects the request and sends a not supported response.

These changes update the bluepy-helper to register for and handle the ATT_OP_MTU_REQ event.  Additional changes were made to btle.py track the MTU and add the ability the to get the current value.
