### PR TITLE
Add optional timeout to writeCharacteristic()

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -555,12 +555,12 @@ class Peripheral(BluepyHelper):
         self._writeCmd("rdu %s %X %X\n" % (UUID(uuid), startHnd, endHnd))
         return self._getResp('rd')
 
-    def writeCharacteristic(self, handle, val, withResponse=False):
+    def writeCharacteristic(self, handle, val, withResponse=False, timeout=None):
         # Without response, a value too long for one packet will be truncated,
         # but with response, it will be sent as a queued write
         cmd = "wrr" if withResponse else "wr"
         self._writeCmd("%s %X %s\n" % (cmd, handle, binascii.b2a_hex(val).decode('utf-8')))
-        return self._getResp('wr')
+        return self._getResp('wr', timeout)
 
     def setSecurityLevel(self, level):
         self._writeCmd("secu %s\n" % level)


### PR DESCRIPTION
As currently implemented writeCharacteristic(..., withResponse=True) gets stuck if peripheral does not respond.