### PR TITLE
Correctly process invalid IO

### DIFF
--- a/bluepy/bluepy-helper.c
+++ b/bluepy/bluepy-helper.c
@@ -857,7 +857,7 @@ static void cmd_connect(int argcp, char **argvp)
         g_error_free(gerr);
         }
     else
-        g_io_add_watch(iochannel, G_IO_HUP, channel_watcher, NULL);
+        g_io_add_watch(iochannel, G_IO_HUP | G_IO_NVAL, channel_watcher, NULL);
 }
 
 static void cmd_disconnect(int argcp, char **argvp)


### PR DESCRIPTION
After the BLE Connection is established, a L2CAP socket will be added the GLib
Poll list via "g_io_add_watch()". But unfortunately the  "G_IO_NVAL" is missing
in the Condition Parameter of the "g_io_add_watch()".

Therefore if Disconnection happens (no matter it's triggered by the BluePy side,
or another side), namely the L2CAP Socket is closed by the Kernel Bluetooth Subsystem .
The missing condition "G_IO_NVAL" causes that the cleanup callback "channel_watcher"
will not be called. In this case, the GIO Event Source will not be removed from the GLib
Poll list properly. And the following infinite Loop happens and raises CPU Usage to 100%.

poll([{fd=0, events=POLLIN}, {fd=4, events=POLLIN}, {fd=5, events=0}], 3, -1) = 2 ([{fd=4, revents=POLLIN}, {fd=5, revents=POLLNVAL}])
// cleanup should happen, but not
poll([{fd=0, events=POLLIN}, {fd=4, events=POLLIN}, {fd=5, events=0}], 3, -1) = 1 ([{fd=5, revents=POLLNVAL}])
poll([{fd=0, events=POLLIN}, {fd=4, events=POLLIN}, {fd=5, events=0}], 3, -1) = 1 ([{fd=5, revents=POLLNVAL}])

Fixes:  #332