### PR TITLE
Give the user a hint the first time they encounter a permision error.

### DIFF
--- a/bluepy/bluepy-helper.c
+++ b/bluepy/bluepy-helper.c
@@ -245,6 +245,16 @@ static void resp_mgmt_err(uint8_t status)
   send_uint(tag_ERRSTAT, status);
   send_str(tag_ERRMSG, mgmt_errstr(status));
   resp_end();
+  static int hint=0;
+  if (status==MGMT_STATUS_PERMISSION_DENIED && !hint++)
+    {
+      fprintf(stderr,
+	      "  Looks like you got a permission error.\n"
+	      "  bluepy-helper needs cap_net_raw+e and cap_net_admin+eip,\n"
+	      "  try setting these as root with setcap(1).\n"
+	      "  See also https://github.com/IanHarvey/bluepy/issues/313\n");
+      fflush(stderr);
+    }
 }
 
 static void cmd_status(int argcp, char **argvp)


### PR DESCRIPTION
"Permission Error", without the information precisely which system/library call failed with which arguments is not all that helpful (and figuring out what exactly fails is not straightforward [1]), so after printing the error reply, point users to #313, which is likely the cause. 

(Alternatively, one could also check capabilities during startup, e.g. using capget(2) or libcap. Might by worth it if any command a user can run needs these capabilities.)

--
[1] strace shows (apparently successful) interactions with both an eventfd (glib event loop related?) and a socket (the actual bluetooth stuff).