### PR TITLE
btle: close the PIPEd stdin and stdout from _helper

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -304,6 +304,7 @@ class BluepyHelper:
             DBG("Stopping ", helperExe)
             self._helper.stdin.write("quit\n")
             self._helper.stdin.flush()
+            self._helper.communicate()
             self._helper.wait()
             self._helper = None
         if self._stderr is not None:


### PR DESCRIPTION
This commit is fixing issue #498 about the annoying log regarding the RessourceWarning.

Signed-off-by: Yoan Dumas <yo_dumas@hotmail.fr>